### PR TITLE
Integrate patches for CVE-2023-3966 and CVE-2023-5366

### DIFF
--- a/SOURCES/openvswitch-2.17.7-CVE-2023-3966-netdev-offload-tc-Check-geneve-metadata-length.backport.patch
+++ b/SOURCES/openvswitch-2.17.7-CVE-2023-3966-netdev-offload-tc-Check-geneve-metadata-length.backport.patch
@@ -1,0 +1,142 @@
+From b8657dada9641fbd2bd3a3f882e0862448d60910 Mon Sep 17 00:00:00 2001
+From: Timothy Redaelli <tredaelli@redhat.com>
+Date: Thu, 23 Nov 2023 19:47:54 +0100
+Subject: [PATCH] netdev-offload-tc: Check geneve metadata length.
+
+Currently ovs-vswitchd crashes, with hw offloading enabled, if a geneve
+packet with corrupted metadata is received, because the metadata header
+is not verified correctly.
+
+This commit adds a check for geneve metadata length and, if the header
+is wrong, the packet is not sent to flower.
+
+It also includes a system-traffic test for geneve packets with corrupted
+metadata.
+
+Fixes: a468645c6d33 ("lib/tc: add geneve with option match offload")
+Reported-by: Haresh Khandelwal <hakhande@redhat.com>
+Signed-off-by: Timothy Redaelli <tredaelli@redhat.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+---
+ lib/netdev-offload-tc.c          | 25 ++++++++++++++++++-----
+ tests/system-offloads-traffic.at | 34 ++++++++++++++++++++++++++++++++
+ 2 files changed, 54 insertions(+), 5 deletions(-)
+
+diff --git a/lib/netdev-offload-tc.c b/lib/netdev-offload-tc.c
+index 7111053c225..f1e9f2f26de 100644
+--- a/lib/netdev-offload-tc.c
++++ b/lib/netdev-offload-tc.c
+@@ -1603,12 +1603,12 @@ test_key_and_mask(struct match *match)
+     return 0;
+ }
+ 
+-static void
++static int
+ flower_match_to_tun_opt(struct tc_flower *flower, const struct flow_tnl *tnl,
+                         struct flow_tnl *tnl_mask)
+ {
+     struct geneve_opt *opt, *opt_mask;
+-    int len, cnt = 0;
++    int tot_opt_len, len, cnt = 0;
+ 
+     /* 'flower' always has an exact match on tunnel metadata length, so having
+      * it in a wrong format is not acceptable unless it is empty. */
+@@ -1624,7 +1624,7 @@ flower_match_to_tun_opt(struct tc_flower *flower, const struct flow_tnl *tnl,
+             memset(&tnl_mask->metadata.present.map, 0,
+                    sizeof tnl_mask->metadata.present.map);
+         }
+-        return;
++        return 0;
+     }
+ 
+     tnl_mask->flags &= ~FLOW_TNL_F_UDPIF;
+@@ -1638,7 +1638,7 @@ flower_match_to_tun_opt(struct tc_flower *flower, const struct flow_tnl *tnl,
+            sizeof tnl_mask->metadata.present.len);
+ 
+     if (!tnl->metadata.present.len) {
+-        return;
++        return 0;
+     }
+ 
+     memcpy(flower->key.tunnel.metadata.opts.gnv, tnl->metadata.opts.gnv,
+@@ -1652,7 +1652,16 @@ flower_match_to_tun_opt(struct tc_flower *flower, const struct flow_tnl *tnl,
+      * also not masks, but actual lengths in the 'flower' structure. */
+     len = flower->key.tunnel.metadata.present.len;
+     while (len) {
++        if (len < sizeof *opt) {
++            return EOPNOTSUPP;
++        }
++
+         opt = &flower->key.tunnel.metadata.opts.gnv[cnt];
++        tot_opt_len = sizeof *opt + opt->length * 4;
++        if (len < tot_opt_len) {
++            return EOPNOTSUPP;
++        }
++
+         opt_mask = &flower->mask.tunnel.metadata.opts.gnv[cnt];
+ 
+         opt_mask->length = opt->length;
+@@ -1660,6 +1669,8 @@ flower_match_to_tun_opt(struct tc_flower *flower, const struct flow_tnl *tnl,
+         cnt += sizeof(struct geneve_opt) / 4 + opt->length;
+         len -= sizeof(struct geneve_opt) + opt->length * 4;
+     }
++
++    return 0;
+ }
+ 
+ static void
+@@ -1841,7 +1852,11 @@ netdev_tc_flow_put(struct netdev *netdev, struct match *match,
+         tnl_mask->flags &= ~(FLOW_TNL_F_DONT_FRAGMENT | FLOW_TNL_F_CSUM);
+ 
+         if (!strcmp(netdev_get_type(netdev), "geneve")) {
+-            flower_match_to_tun_opt(&flower, tnl, tnl_mask);
++            err = flower_match_to_tun_opt(&flower, tnl, tnl_mask);
++            if (err) {
++                VLOG_WARN_RL(&warn_rl, "Unable to parse geneve options");
++                return err;
++            }
+         }
+         flower.tunnel = true;
+     } else {
+diff --git a/tests/system-offloads-traffic.at b/tests/system-offloads-traffic.at
+index 1a7f1e827a9..9d47461cc21 100644
+--- a/tests/system-offloads-traffic.at
++++ b/tests/system-offloads-traffic.at
+@@ -349,3 +349,37 @@ OVS_TRAFFIC_VSWITCHD_STOP(["/could not open network device ovs-p0/d
+ /failed to offload flow/d
+ "])
+ AT_CLEANUP
++
++AT_SETUP([offloads - handling of geneve corrupted metadata - offloads enabled])
++OVS_CHECK_GENEVE()
++
++OVS_TRAFFIC_VSWITCHD_START(
++    [_ADD_BR([br-underlay]) -- \
++     set bridge br0 other-config:hwaddr=f2:ff:00:00:00:01 -- \
++     set bridge br-underlay other-config:hwaddr=f2:ff:00:00:00:02])
++
++AT_CHECK([ovs-vsctl set Open_vSwitch . other_config:hw-offload=true])
++
++AT_CHECK([ovs-ofctl add-flow br0 "actions=normal"])
++AT_CHECK([ovs-ofctl add-flow br-underlay "actions=normal"])
++
++ADD_NAMESPACES(at_ns0)
++
++dnl Set up underlay link from host into the namespace using veth pair.
++ADD_VETH(p0, at_ns0, br-underlay, "172.31.1.1/24", f2:ff:00:00:00:03)
++AT_CHECK([ip addr add dev br-underlay "172.31.1.100/24"])
++AT_CHECK([ip link set dev br-underlay up])
++
++dnl Set up tunnel endpoints on OVS outside the namespace and with a native
++dnl linux device inside the namespace.
++ADD_OVS_TUNNEL([geneve], [br0], [at_gnv0], [172.31.1.1], [10.1.1.100/24])
++ADD_NATIVE_TUNNEL([geneve], [ns_gnv0], [at_ns0], [172.31.1.100], [10.1.1.1/24],
++                  [vni 0], [address f2:ff:00:00:00:04])
++
++NS_CHECK_EXEC([at_ns0], [$PYTHON3 $srcdir/sendpkt.py p0 f2 ff 00 00 00 02 f2 ff 00 00 00 03 08 00 45 00 00 52 00 01 00 00 40 11 1f f7 ac 1f 01 01 ac 1f 01 64 de c1 17 c1 00 3e 59 e9 01 00 65 58 00 00 00 00 00 03 00 02 f2 ff 00 00 00 01 f2 ff 00 00 00 04 08 00 45 00 00 1c 00 01 00 00 40 01 64 7a 0a 01 01 01 0a 01 01 64 08 00 f7 ff 00 00 00 00  > /dev/null])
++
++OVS_WAIT_UNTIL([grep -q 'Invalid Geneve tunnel metadata' ovs-vswitchd.log])
++
++OVS_TRAFFIC_VSWITCHD_STOP(["/Invalid Geneve tunnel metadata on bridge br0 while processing icmp,in_port=1,vlan_tci=0x0000,dl_src=f2:ff:00:00:00:04,dl_dst=f2:ff:00:00:00:01,nw_src=10.1.1.1,nw_dst=10.1.1.100,nw_tos=0,nw_ecn=0,nw_ttl=64,nw_frag=no,icmp_type=8,icmp_code=0/d
++/Unable to parse geneve options/d"])
++AT_CLEANUP

--- a/SOURCES/openvswitch-2.17.7-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
+++ b/SOURCES/openvswitch-2.17.7-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
@@ -1,0 +1,175 @@
+From e235a421fbdb0c70176e8a3bef13bf7e2056cbc1 Mon Sep 17 00:00:00 2001
+From: Aaron Conole <aconole@redhat.com>
+Date: Mon, 11 Dec 2023 12:04:19 -0500
+Subject: [PATCH] odp: ND: Follow Open Flow spec converting from OF to DP.
+
+The OpenFlow spec doesn't require that a user specify icmp_code when
+specifying a type.  However, the conversion for a DP flow asks that the
+user explicitly specified an icmp_code field to match and forces this via
+a mask check.  This means that valid matches for icmp_type=136,... (for
+example) won't properly generate a full flow and there will be a much
+broader match installed in the kernel datapath.
+
+This can be worked around by explicitly including icmp_code, but for users
+that want to write flows which are installed in the kernel, it is not
+possible to omit icmp_code in the openflow message and still have a
+neighbor discovery match field included.
+
+An alternative way to fix up the flow and mask would be to modify the
+output of the translation in the xlate_wc_finish() to set the mask when
+detecting a neighbor discovery related packet.  This would require
+additional matching logic in the xlate_wc_finish() path to validate the
+ICMP type/code details, and set the masks correctly.
+
+The approach taken here is to relax the requirements from the ODP side.
+This follows the OpenFlow specification and only require that the user
+include an 'icmp_type=' match, rather than both
+'icmp_type=..,icmp_code=0' when matching on neighbor discovery.
+
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+---
+ lib/odp-util.c          | 31 +++++++++++--------------
+ tests/ofproto-macros.at | 15 ++++++++++++
+ tests/system-traffic.at | 51 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 79 insertions(+), 18 deletions(-)
+
+diff --git a/lib/odp-util.c b/lib/odp-util.c
+index fac4cf3a8c8..aa49fbebb73 100644
+--- a/lib/odp-util.c
++++ b/lib/odp-util.c
+@@ -6402,12 +6402,10 @@ odp_flow_key_from_flow__(const struct odp_flow_key_parms *parms,
+             icmpv6_key->icmpv6_code = ntohs(data->tp_dst);
+ 
+             if (is_nd(flow, NULL)
+-                /* Even though 'tp_src' and 'tp_dst' are 16 bits wide, ICMP
+-                 * type and code are 8 bits wide.  Therefore, an exact match
+-                 * looks like htons(0xff), not htons(0xffff).  See
+-                 * xlate_wc_finish() for details. */
+-                && (!export_mask || (data->tp_src == htons(0xff)
+-                                     && data->tp_dst == htons(0xff)))) {
++                /* Even though 'tp_src' is 16 bits wide, ICMP type is 8 bits
++                 * wide.  Therefore, an exact match looks like htons(0xff),
++                 * not htons(0xffff).  See xlate_wc_finish() for details. */
++                && (!export_mask || data->tp_src == htons(0xff))) {
+                 struct ovs_key_nd *nd_key;
+                 nd_key = nl_msg_put_unspec_uninit(buf, OVS_KEY_ATTR_ND,
+                                                     sizeof *nd_key);
+@@ -7122,20 +7120,17 @@ parse_l2_5_onward(const struct nlattr *attrs[OVS_KEY_ATTR_MAX + 1],
+                     flow->arp_sha = nd_key->nd_sll;
+                     flow->arp_tha = nd_key->nd_tll;
+                     if (is_mask) {
+-                        /* Even though 'tp_src' and 'tp_dst' are 16 bits wide,
+-                         * ICMP type and code are 8 bits wide.  Therefore, an
+-                         * exact match looks like htons(0xff), not
+-                         * htons(0xffff).  See xlate_wc_finish() for details.
+-                         * */
++                        /* Even though 'tp_src' is 16 bits wide, ICMP type
++                         * is 8 bits wide.  Therefore, an exact match looks
++                         * like htons(0xff), not htons(0xffff).  See
++                         * xlate_wc_finish() for details. */
+                         if (!is_all_zeros(nd_key, sizeof *nd_key) &&
+-                            (flow->tp_src != htons(0xff) ||
+-                             flow->tp_dst != htons(0xff))) {
++                            flow->tp_src != htons(0xff)) {
+                             odp_parse_error(&rl, errorp,
+-                                            "ICMP (src,dst) masks should be "
+-                                            "(0xff,0xff) but are actually "
+-                                            "(%#"PRIx16",%#"PRIx16")",
+-                                            ntohs(flow->tp_src),
+-                                            ntohs(flow->tp_dst));
++                                            "ICMP src mask should be "
++                                            "(0xff) but is actually "
++                                            "(%#"PRIx16")",
++                                            ntohs(flow->tp_src));
+                             return ODP_FIT_ERROR;
+                         } else {
+                             *expected_attrs |= UINT64_C(1) << OVS_KEY_ATTR_ND;
+diff --git a/tests/ofproto-macros.at b/tests/ofproto-macros.at
+index b18f0fbc1e9..9e32f53c0cd 100644
+--- a/tests/ofproto-macros.at
++++ b/tests/ofproto-macros.at
+@@ -141,6 +141,21 @@ strip_stats () {
+     s/bytes:[[0-9]]*/bytes:0/'
+ }
+ 
++# Strips key32 field from output.
++strip_key32 () {
++    sed 's/key32([[0-9 \/]]*),//'
++}
++
++# Strips packet-type from output.
++strip_ptype () {
++    sed 's/packet_type(ns=[[0-9]]*,id=[[0-9]]*),//'
++}
++
++# Strips bare eth from output.
++strip_eth () {
++    sed 's/eth(),//'
++}
++
+ # Changes all 'recirc(...)' and 'recirc=...' to say 'recirc(<recirc_id>)' and
+ # 'recirc=<recirc_id>' respectively.  This should make output easier to
+ # compare.
+diff --git a/tests/system-traffic.at b/tests/system-traffic.at
+index f9668784b8f..099e9728128 100644
+--- a/tests/system-traffic.at
++++ b/tests/system-traffic.at
+@@ -2030,6 +2030,57 @@ recirc_id(<recirc>),in_port(3),eth_type(0x0800),ipv4(frag=no), packets:29, bytes
+ OVS_TRAFFIC_VSWITCHD_STOP
+ AT_CLEANUP
+ 
++AT_SETUP([datapath - Neighbor Discovery with loose match])
++OVS_TRAFFIC_VSWITCHD_START()
++
++ADD_NAMESPACES(at_ns0, at_ns1)
++
++ADD_VETH(p0, at_ns0, br0, "2001::1:0:392/64", 36:b1:ee:7c:01:03)
++ADD_VETH(p1, at_ns1, br0, "2001::1:0:9/64", 36:b1:ee:7c:01:02)
++
++dnl Set up flows for moving icmp ND Solicit around.  This should be the
++dnl same for the other ND types.
++AT_DATA([flows.txt], [dnl
++table=0 priority=95 icmp6,icmp_type=136,nd_target=2001::1:0:9 actions=resubmit(,10)
++table=0 priority=95 icmp6,icmp_type=136,nd_target=2001::1:0:392 actions=resubmit(,10)
++table=0 priority=65 actions=resubmit(,20)
++table=10 actions=NORMAL
++table=20 actions=drop
++])
++AT_CHECK([ovs-ofctl del-flows br0])
++AT_CHECK([ovs-ofctl --bundle add-flows br0 flows.txt])
++
++dnl Send a mismatching neighbor discovery.
++NS_CHECK_EXEC([at_ns0], [$PYTHON3 $srcdir/sendpkt.py p0 36 b1 ee 7c 01 02 36 b1 ee 7c 01 03 86 dd 60 00 00 00 00 20 3a ff fe 80 00 00 00 00 00 00 f8 16 3e ff fe 04 66 04 fe 80 00 00 00 00 00 00 f8 16 3e ff fe a7 dd 0e 88 00 f1 f2 20 00 00 00 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 02 01 36 b1 ee 7c 01 03 > /dev/null])
++
++dnl Send a matching neighbor discovery.
++NS_CHECK_EXEC([at_ns0], [$PYTHON3 $srcdir/sendpkt.py p0 36 b1 ee 7c 01 02 36 b1 ee 7c 01 03 86 dd 60 00 00 00 00 20 3a ff fe 80 00 00 00 00 00 00 f8 16 3e ff fe 04 66 04 fe 80 00 00 00 00 00 00 f8 16 3e ff fe a7 dd 0e 88 00 fe 5f 20 00 00 00 20 01 00 00 00 00 00 00 00 00 00 01 00 00 03 92 02 01 36 b1 ee 7c 01 03 > /dev/null])
++
++AT_CHECK([ovs-appctl dpctl/dump-flows | strip_stats | strip_used | dnl
++          strip_key32 | strip_ptype | strip_eth | strip_recirc | dnl
++          grep ",nd" | sort], [0], [dnl
++recirc_id(<recirc>),in_port(2),eth(src=36:b1:ee:7c:01:03,dst=36:b1:ee:7c:01:02),eth_type(0x86dd),ipv6(proto=58,frag=no),icmpv6(type=136),nd(target=2001::1:0:392), packets:0, bytes:0, used:never, actions:1,3
++recirc_id(<recirc>),in_port(2),eth_type(0x86dd),ipv6(proto=58,frag=no),icmpv6(type=136),nd(target=3000::1), packets:0, bytes:0, used:never, actions:drop
++])
++
++OVS_WAIT_UNTIL([ovs-appctl dpctl/dump-flows | grep ",nd" | wc -l | grep -E ^0])
++
++dnl Send a matching neighbor discovery.
++NS_CHECK_EXEC([at_ns0], [$PYTHON3 $srcdir/sendpkt.py p0 36 b1 ee 7c 01 02 36 b1 ee 7c 01 03 86 dd 60 00 00 00 00 20 3a ff fe 80 00 00 00 00 00 00 f8 16 3e ff fe 04 66 04 fe 80 00 00 00 00 00 00 f8 16 3e ff fe a7 dd 0e 88 00 fe 5f 20 00 00 00 20 01 00 00 00 00 00 00 00 00 00 01 00 00 03 92 02 01 36 b1 ee 7c 01 03 > /dev/null])
++
++dnl Send a mismatching neighbor discovery.
++NS_CHECK_EXEC([at_ns0], [$PYTHON3 $srcdir/sendpkt.py p0 36 b1 ee 7c 01 02 36 b1 ee 7c 01 03 86 dd 60 00 00 00 00 20 3a ff fe 80 00 00 00 00 00 00 f8 16 3e ff fe 04 66 04 fe 80 00 00 00 00 00 00 f8 16 3e ff fe a7 dd 0e 88 00 f1 f2 20 00 00 00 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 02 01 36 b1 ee 7c 01 03 > /dev/null])
++
++AT_CHECK([ovs-appctl dpctl/dump-flows | strip_stats | strip_used | dnl
++          strip_key32 | strip_ptype | strip_eth | strip_recirc | dnl
++          grep ",nd" | sort], [0], [dnl
++recirc_id(<recirc>),in_port(2),eth(src=36:b1:ee:7c:01:03,dst=36:b1:ee:7c:01:02),eth_type(0x86dd),ipv6(proto=58,frag=no),icmpv6(type=136),nd(target=2001::1:0:392), packets:0, bytes:0, used:never, actions:1,3
++recirc_id(<recirc>),in_port(2),eth_type(0x86dd),ipv6(proto=58,frag=no),icmpv6(type=136),nd(target=3000::1), packets:0, bytes:0, used:never, actions:drop
++])
++
++OVS_TRAFFIC_VSWITCHD_STOP
++AT_CLEANUP
++
+ AT_BANNER([MPLS])
+ 
+ AT_SETUP([mpls - encap header dp-support])

--- a/SPECS/openvswitch.spec
+++ b/SPECS/openvswitch.spec
@@ -16,7 +16,7 @@ Summary: Virtual switch
 URL: http://www.openvswitch.org/
 Version: 2.17.7
 License: ASL 2.0 and GPLv2
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 Source0: openvswitch-2.17.7.tar.gz
 Patch0: CA-72973-hack-to-strip-temp-dirs-from-paths.patch
 Patch1: CP-15129-Convert-to-use-systemd-services.patch
@@ -38,6 +38,8 @@ Patch15: hide-logrotate-script-error.patch
 # XCP-ng patches
 Patch1000: openvswitch-2.17.7-comment-failing-tests.XCP-ng.patch
 Patch1001: openvswitch-2.17.7-add-pythonpath-ipsec.XCP-ng.patch
+Patch1002: openvswitch-2.17.7-CVE-2023-3966-netdev-offload-tc-Check-geneve-metadata-length.backport.patch
+Patch1003: openvswitch-2.17.7-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
 
 Requires(post): systemd
 Requires(preun): systemd
@@ -350,6 +352,10 @@ tunnels using IPsec.
 %systemd_postun openvswitch-ipsec.service
 
 %changelog
+* Fri Mar 01 2024 David Morel <david.morel@vates.tech> - 2.17.7-1.2
+- Apply fix for CVE-2023-3966, provided in advisory
+- Apply fix for CVE-2023-5366, provided in advisory
+
 * Mon Jan 22 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.17.7-1.1
 - Update to 2.17.7-1
 - Add openvswitch-2.17.7-comment-failing-tests.XCP-ng.patch (Benjamin Reis)


### PR DESCRIPTION
- CVE-2023-3966: Open vSwitch: Invalid memory access in Geneve with HW offload.
- CVE-2023-5366: Open vSwitch: OpenFlow match on Neighbor Discovery Target may be ignored