### PR TITLE
Link with xs-openssl and load custom configuration

### DIFF
--- a/SOURCES/fix-dhparams-gen.patch
+++ b/SOURCES/fix-dhparams-gen.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/automake.mk b/lib/automake.mk
+index 5387d51..5b737f3 100644
+--- a/lib/automake.mk
++++ b/lib/automake.mk
+@@ -407,7 +407,8 @@ lib/dhparams.c: lib/dh1024.pem lib/dh2048.pem lib/dh4096.pem
+ 	 openssl dhparam -C -in $(srcdir)/lib/dh1024.pem -noout &&	\
+ 	 openssl dhparam -C -in $(srcdir)/lib/dh2048.pem -noout &&	\
+ 	 openssl dhparam -C -in $(srcdir)/lib/dh4096.pem -noout)	\
+-	| sed 's/\(get_dh[0-9]*\)()/\1(void)/' > lib/dhparams.c.tmp &&  \
++	| sed 's/\(get_dh[0-9]*\)()/\1(void)/'	\
++	| sed 's/^static DH/DH/' > lib/dhparams.c.tmp &&  \
+ 	mv lib/dhparams.c.tmp lib/dhparams.c
+ else
+ lib_libopenvswitch_la_SOURCES += lib/stream-nossl.c

--- a/SOURCES/ovsdb-server-custom-openssl-config-to-limit-ciphers-and-protocols.patch
+++ b/SOURCES/ovsdb-server-custom-openssl-config-to-limit-ciphers-and-protocols.patch
@@ -1,0 +1,59 @@
+From 78c25fcf97b2f84df8eabbc8631be3e936c4a542 Mon Sep 17 00:00:00 2001
+From: David Morel <david.morel@vates.tech>
+Date: Tue, 11 Jun 2024 08:39:26 +0200
+Subject: [PATCH] ovsdb-server: custom openssl config to limit ciphers and
+ protocols
+
+- Add an XCP-ng specific openssl configuration file limiting the ciphers
+  and protocols used by ovsdb-server, to avoid weak ciphers
+- Add an OPENSSL_CONF environment variable to point to the new
+  configuration file at startup
+
+Signed-off-by: David Morel <david.morel@vates.tech>
+---
+ .../etc_openvswitch_openssl-xcpng-ovsdb.conf  | 20 +++++++++++++++++++
+ ...usr_lib_systemd_system_openvswitch.service |  1 +
+ 2 files changed, 21 insertions(+)
+ create mode 100644 xcp-ng/etc_openvswitch_openssl-xcpng-ovsdb.conf
+
+diff --git a/xcp-ng/etc_openvswitch_openssl-xcpng-ovsdb.conf b/xcp-ng/etc_openvswitch_openssl-xcpng-ovsdb.conf
+new file mode 100644
+index 0000000..b2184c1
+--- /dev/null
++++ b/xcp-ng/etc_openvswitch_openssl-xcpng-ovsdb.conf
+@@ -0,0 +1,20 @@
++# XCP-ng's OpenSSL configuration file to restrict TLS versions to TLS 1.2 and
++# TLS 1.3 so ovsdb-server won't expose older protocols. Requires an openvswitch
++# version linked with xs-openssl as openssl 1.0.2 has no support for such a
++# configuration.
++
++openssl_conf = openssl_init
++
++[openssl_init]
++ssl_conf = ssl_sect
++
++[ssl_sect]
++system_default = system_default_sect
++
++[system_default_sect]
++MinProtocol = TLSv1.2
++MaxProtocol = TLSv1.3
++
++# Althrough xs-openssl should now be built with no-weak-ciphers, specify a list
++# here, with a default value, but we could easily make a custom list if needed.
++CipherString = DEFAULT@SECLEVEL=2
+diff --git a/xenserver/usr_lib_systemd_system_openvswitch.service b/xenserver/usr_lib_systemd_system_openvswitch.service
+index 31f18ef..0e071bc 100644
+--- a/xenserver/usr_lib_systemd_system_openvswitch.service
++++ b/xenserver/usr_lib_systemd_system_openvswitch.service
+@@ -7,6 +7,7 @@ PartOf=network.target
+ [Service]
+ Type=forking
+ Environment=ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
++Environment=OPENSSL_CONF=/etc/openvswitch/openssl-xcpng-ovsdb.conf
+ ExecStart=/usr/share/openvswitch/scripts/ovs-start
+ ExecStop=/usr/share/openvswitch/scripts/ovs-ctl stop
+ OOMScoreAdjust=-1000
+-- 
+2.45.1
+

--- a/SPECS/openvswitch.spec
+++ b/SPECS/openvswitch.spec
@@ -9,7 +9,7 @@ Summary: Virtual switch
 URL: http://www.openvswitch.org/
 Version: 2.5.3
 License: ASL 2.0 and GPLv2
-Release: 2.3.12.2%{?dist}
+Release: 2.3.12.3%{?dist}
 
 Source0: openvswitch.tar.gz
 Source1: openvswitch-ipsec.service
@@ -57,6 +57,10 @@ Patch1000: openvswitch-2.5.3-CVE-2023-1668-ofproto-dpif-xlate-Always-mask-ip-pro
 Patch1001: openvswitch-2.5.3-comment-failing-tests.XCP-ng.patch
 # Upsteam CVE fix
 Patch1002: openvswitch-2.5.3-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
+# Fix dhparams.c generation with openssl 1.1.1 (from xs-openssl)
+Patch1003: fix-dhparams-gen.patch
+# Avoid exposing weak ciphers though an openssl configuration file
+Patch1004: ovsdb-server-custom-openssl-config-to-limit-ciphers-and-protocols.patch
 
 Provides: gitsha(ssh://git@code.citrite.net/XSU/openvswitch.git) = e954fdbfa97a1a357a4dcfff80f5bd916a2eb647
 Provides: gitsha(ssh://git@code.citrite.net/XS/openvswitch.pg.git) = 0420b368c506f3bc646488862ea47bec2b7ef67b
@@ -65,7 +69,7 @@ Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 BuildRequires: systemd
-BuildRequires: glibc-static, kernel-devel, openssl, openssl-devel, openssl-static, python
+BuildRequires: glibc-static, kernel-devel, xs-openssl, xs-openssl-devel, xs-openssl-libs, python
 BuildRequires: autoconf, automake, libtool
 %if %{with_asan}
 BuildRequires: libasan
@@ -129,6 +133,8 @@ install -d -m 755 %{buildroot}/var/log/openvswitch
 install -d -m 755 %{buildroot}/var/xen/openvswitch
 
 install -d -m 755 %{buildroot}/%{_sysconfdir}/openvswitch
+install -m 644 xcp-ng/etc_openvswitch_openssl-xcpng-ovsdb.conf \
+            %{buildroot}/%{_sysconfdir}/openvswitch/openssl-xcpng-ovsdb.conf
 
 install -d -m 755 %{buildroot}/%{_sysconfdir}/sysconfig
 install -m 755 xenserver/usr_share_openvswitch_scripts_sysconfig.template \
@@ -191,6 +197,7 @@ make check
 %config %{_sysconfdir}/logrotate.d/openvswitch
 %{_sysconfdir}/xapi.d/plugins/openvswitch-cfg-update
 %dir %{_sysconfdir}/openvswitch
+%config %{_sysconfdir}/openvswitch/openssl-xcpng-ovsdb.conf
 %dir /run/openvswitch
 %dir %{_var}/xen/openvswitch
 %dir %{_var}/lib/openvswitch
@@ -376,6 +383,11 @@ tunnels using IPsec.
 %systemd_postun openvswitch-ipsec.service
 
 %changelog
+* Mon Jun 10 2024 David Morel <david.morel@vates.tech> - 2.5.3-2.3.12.3
+- link with xs-openssl instead of openssl
+- fix compilation with an openssl from 1.1.1 branch
+- add an openssl configuration to disable weak ciphers and older TLS versions
+
 * Wed Feb 28 2024 David Morel <david.morel@vates.tech> - 2.5.3-2.3.12.2
 - Comment out tests that fail
 - Enable make check in spec file, without parallel tests


### PR DESCRIPTION
- Link with xs-openssl instead of openssl, moving from 1.0.2 to 1.1.1 which is more up to date, with more CVEs fixes, and support custom openssl configuration file loading
- Fix DH parameter generation using newer openssl
- Add a custom openssl configuration that disables weak cihpers, and older TLS protocol versions