### PR TITLE
Link with xs-openssl and specify ciphers and protocols

### DIFF
--- a/SOURCES/ovs-ctl-set-default-ssl-ciphers-and-protocols.patch
+++ b/SOURCES/ovs-ctl-set-default-ssl-ciphers-and-protocols.patch
@@ -1,0 +1,32 @@
+From a3eaf22e96063546ecf5734e87ac688c20044c11 Mon Sep 17 00:00:00 2001
+From: David Morel <david.morel@vates.tech>
+Date: Fri, 21 Jun 2024 11:46:24 +0200
+Subject: [PATCH] ovs-ctl: set default ssl ciphers and protocols
+
+Avoid weak ciphers using the command line options available in this
+version of openvswitch (2.17). On older version (2.5) we used an openssl
+configuration file to do so, but this version overrides the
+settings in the configuration, so we have to use the command line
+parameters --ssl-ciphers and --ssl-protocols.
+
+Signed-off-by: David Morel <david.morel@vates.tech>
+---
+ utilities/ovs-ctl.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utilities/ovs-ctl.in b/utilities/ovs-ctl.in
+index e6e07f4..a500e70 100644
+--- a/utilities/ovs-ctl.in
++++ b/utilities/ovs-ctl.in
+@@ -340,7 +340,7 @@ set_defaults () {
+     OVS_VSWITCHD_PRIORITY=-10
+     OVSDB_SERVER_WRAPPER=
+     OVS_VSWITCHD_WRAPPER=
+-    OVSDB_SERVER_OPTIONS=
++    OVSDB_SERVER_OPTIONS="--ssl-ciphers=ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256 --ssl-protocols=TLSv1.2,TLSv1.3"
+     OVS_VSWITCHD_OPTIONS=
+ 
+     DB_FILE=$dbdir/conf.db
+-- 
+2.45.1
+

--- a/SPECS/openvswitch.spec
+++ b/SPECS/openvswitch.spec
@@ -16,7 +16,7 @@ Summary: Virtual switch
 URL: http://www.openvswitch.org/
 Version: 2.17.7
 License: ASL 2.0 and GPLv2
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 Source0: openvswitch-2.17.7.tar.gz
 Patch0: CA-72973-hack-to-strip-temp-dirs-from-paths.patch
 Patch1: CP-15129-Convert-to-use-systemd-services.patch
@@ -40,12 +40,13 @@ Patch1000: openvswitch-2.17.7-comment-failing-tests.XCP-ng.patch
 Patch1001: openvswitch-2.17.7-add-pythonpath-ipsec.XCP-ng.patch
 Patch1002: openvswitch-2.17.7-CVE-2023-3966-netdev-offload-tc-Check-geneve-metadata-length.backport.patch
 Patch1003: openvswitch-2.17.7-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
+Patch1004: ovs-ctl-set-default-ssl-ciphers-and-protocols.patch
 
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 BuildRequires: systemd
-BuildRequires: openssl, openssl-devel, python3
+BuildRequires: xs-openssl, xs-openssl-devel, python3
 BuildRequires: autoconf, automake, libtool
 %if %{with_asan}
 BuildRequires: libasan
@@ -352,6 +353,12 @@ tunnels using IPsec.
 %systemd_postun openvswitch-ipsec.service
 
 %changelog
+* Fri Jun 21 2024 David Morel <david.morel@vates.tech> - 2.17.7-1.3
+- Link with xs-openssl instead of openssl
+- Tweak ovs-ctl script that is used to start ovsdb-server, passing it
+  --ssl-ciphers and --ssl-protocols command line parameters to disable weak
+  ciphers.
+
 * Fri Mar 01 2024 David Morel <david.morel@vates.tech> - 2.17.7-1.2
 - Apply fix for CVE-2023-3966, provided in advisory
 - Apply fix for CVE-2023-5366, provided in advisory


### PR DESCRIPTION
- Link with xs-openssl instead of openssl, moving from 1.0.2 to 1.1.1 which is more up to date, with more CVEs fixes, and support custom openssl configuration file loading
- Patch ovs-ctl script to use --ssl-ciphers to fully disable weak ciphers and --ssl-protocols to limit to TLS v1.2 and v1.3