### PR TITLE
Integrate patch for CVE-2022-4337 and CVE-2022-4338

### DIFF
--- a/SOURCES/openvswitch-2.5.3-CVE-2022-4337-CVE-2022-4338.backport.patch
+++ b/SOURCES/openvswitch-2.5.3-CVE-2022-4337-CVE-2022-4338.backport.patch
@@ -1,0 +1,92 @@
+Backport notes:
+There is a much larger test series that we do not have at home.
+I have repositioned the test to where it should be.
+I have adapted the test format which has evolved so it can be executed
+
+From 7490f281f09a8455c48e19b0cf1b99ab758ee4f4 Mon Sep 17 00:00:00 2001
+From: Qian Chen <cq674350529@163.com>
+Date: Tue, 20 Dec 2022 09:36:08 -0500
+Subject: [PATCH] lldp: Fix bugs when parsing malformed AutoAttach.
+
+The OVS LLDP implementation includes support for AutoAttach standard, which
+the 'upstream' lldpd project does not include.  As part of adding this
+support, the message parsing for these TLVs did not include proper length
+checks for the LLDP_TLV_AA_ELEMENT_SUBTYPE and the
+LLDP_TLV_AA_ISID_VLAN_ASGNS_SUBTYPE elements.  The result is that a message
+without a proper boundary will cause an overread of memory, and lead to
+undefined results, including crashes or other unidentified behavior.
+
+The fix is to introduce proper bounds checking for these elements.  Introduce
+a unit test to ensure that we have some proper rejection in this code
+base in the future.
+
+Fixes: be53a5c447c3 ("auto-attach: Initial support for Auto-Attach standard")
+
+Upstream-Status: Backport from upstream [https://github.com/openvswitch/ovs/commit/7490f281f09a8455c48e19b0cf1b99ab758ee4f4]
+CVE: CVE-2022-4337 - openvswitch: Out-of-Bounds Read in Organization Specific TLV
+CVE: CVE-2022-4338 - openvswitch: Integer Underflow in Organization Specific TLV
+
+Signed-off-by: Qian Chen <cq674350529@163.com>
+Co-authored-by: Aaron Conole <aconole@redhat.com>
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+Signed-off-by: Xiangyu Chen <xiangyu.chen@windriver.com>
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ lib/lldp/lldp.c       |  2 ++
+ tests/ofproto-dpif.at | 19 +++++++++++++++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/lib/lldp/lldp.c b/lib/lldp/lldp.c
+index dfeb2a800..6fdcfef56 100644
+--- a/lib/lldp/lldp.c
++++ b/lib/lldp/lldp.c
+@@ -583,6 +583,7 @@ lldp_decode(struct lldpd *cfg OVS_UNUSED, char *frame, int s,
+ 
+                 switch(tlv_subtype) {
+                 case LLDP_TLV_AA_ELEMENT_SUBTYPE:
++                    CHECK_TLV_SIZE(50, "ELEMENT");
+                     PEEK_BYTES(&msg_auth_digest, sizeof msg_auth_digest);
+ 
+                     aa_element_dword = PEEK_UINT32;
+@@ -629,6 +630,7 @@ lldp_decode(struct lldpd *cfg OVS_UNUSED, char *frame, int s,
+                     break;
+ 
+                 case LLDP_TLV_AA_ISID_VLAN_ASGNS_SUBTYPE:
++                    CHECK_TLV_SIZE(36, "ISID_VLAN_ASGNS");
+                     PEEK_BYTES(&msg_auth_digest, sizeof msg_auth_digest);
+ 
+                     /* Subtract off tlv type and length (2Bytes) + OUI (3B) +
+diff --git a/tests/ofproto-dpif.at b/tests/ofproto-dpif.at
+index eb4cd1896..fa6111c1e 100644
+--- a/tests/ofproto-dpif.at
++++ b/tests/ofproto-dpif.at
+@@ -62,6 +62,25 @@ AT_CHECK([cat ovs-vswitchd.log | grep 'in_port=[[348]]' | FILTER_FLOW_INSTALL | STRIP_XOUT], [0], [dnl
+ OVS_VSWITCHD_STOP
+ AT_CLEANUP
+ 
++AT_SETUP([ofproto-dpif - malformed lldp autoattach tlv])
++OVS_VSWITCHD_START()
++ADD_OF_PORTS([br0], [1])
++
++dnl Enable lldp
++AT_CHECK([ovs-vsctl set interface p1 lldp:enable=true])
++
++dnl Send a malformed lldp packet
++packet="0180c200000ef6b426aa5f0088cc020704f6b426aa5f000403057632060200780c"dnl
++"5044454144424545464445414442454546444541444245454644454144424545464445414"dnl
++"4424545464445414442454546444541444245454644454144424545464445414442454546"dnl
++"4445414442454546fe0500040d0c010000"
++AT_CHECK([ovs-appctl netdev-dummy/receive p1 "$packet"], [0], [stdout])
++
++OVS_WAIT_UNTIL([grep -q "ISID_VLAN_ASGNS TLV too short" ovs-vswitchd.log])
++
++OVS_VSWITCHD_STOP(["/|WARN|ISID_VLAN_ASGNS TLV too short received on/d"])
++AT_CLEANUP
++
+ AT_SETUP([ofproto-dpif - balance-slb bonding])
+ # Create br0 with interfaces bond0(p1, p2, p3) and p7,
+
+-- 
+2.34.1
+

--- a/SPECS/openvswitch.spec
+++ b/SPECS/openvswitch.spec
@@ -15,7 +15,7 @@ Summary: Virtual switch
 URL: http://www.openvswitch.org/
 Version: 2.5.3
 License: ASL 2.0 and GPLv2
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 
 Source0: openvswitch-2.5.3.tar.gz
 Source1: openvswitch-ipsec.service
@@ -62,6 +62,7 @@ Patch35: hide-logrotate-script-error.patch
 Patch1000: openvswitch-2.5.3-comment-failing-tests.XCP-ng.patch
 # Upsteam CVE fix
 Patch1001: openvswitch-2.5.3-CVE-2023-5366-odp-ND-Follow-Open-Flow-spec-converting-from-OF-to-DP.backport.patch
+Patch1002: openvswitch-2.5.3-CVE-2022-4337-CVE-2022-4338.backport.patch
 
 Requires(post): systemd
 Requires(preun): systemd
@@ -377,6 +378,10 @@ tunnels using IPsec.
 %systemd_postun openvswitch-ipsec.service
 
 %changelog
+* Tue Feb 25 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 2.5.3-2.3.14.2
+- Fix DOS with a malformed packet on LLDP
+  (CVE-2022-4337 & CVE-2022-4338)
+
 * Tue Jan 30 2025 David Morel <david.morel@vates.tech> - 2.5.3-2.3.14.1
 - Sync with hotfix XS82ECU1081
 - *** Upstream changelog ***


### PR DESCRIPTION
Integration of a patch to correct the vulnerabilities CVE-2022-4337 & CVE-2022-4338 which allowed
to read the memory, or to crash OVS