### PR TITLE
Import openvswitch-2.17.7-4.xs8.src.rpm as part of XS-1557

### DIFF
--- a/SOURCES/0001-docs-Add-nowarn-region-option-to-tables.patch
+++ b/SOURCES/0001-docs-Add-nowarn-region-option-to-tables.patch
@@ -1,0 +1,66 @@
+From e46d455201d08725687dc90d3d0ee99fe8f70ca6 Mon Sep 17 00:00:00 2001
+From: Frode Nordahl <frode.nordahl@canonical.com>
+Date: Mon, 21 Aug 2023 15:53:33 +0200
+Subject: [PATCH] docs: Add `nowarn` region option to tables.
+
+Starting with groff 1.23.0 a warning is produced if the tbl
+preprocessor is not run.  A side effect of enabling it is that
+new warnings on table formatting is printed.
+
+As requested during the review [0] of a series [1] attempting to
+address this, this patch makes use of the `nowarn` region option
+as opposed to attempting to change the formatting.
+
+0: https://patchwork.ozlabs.org/project/openvswitch/patch/ZM00Wfa80rOb2oCA@riva.ucam.org/#3164177
+1: https://patchwork.ozlabs.org/project/openvswitch/list/?series=367378&state=*
+
+Reported-by: Lucas Nussbaum <lucas@debian.org>
+Reported-at: https://bugs.debian.org/1042358
+Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+---
+ build-aux/extract-ofp-fields | 6 +++---
+ lib/meta-flow.xml            | 1 +
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff -ur openvswitch-2.17.7.orig/build-aux/extract-ofp-fields openvswitch-2.17.7/build-aux/extract-ofp-fields
+--- openvswitch-2.17.7.orig/build-aux/extract-ofp-fields	2023-06-27 14:30:44.000000000 +0000
++++ openvswitch-2.17.7/build-aux/extract-ofp-fields	2025-01-22 13:58:34.757155550 +0000
+@@ -578,7 +578,7 @@
+     body += [""".PP
+ \\fB%s Field\\fR
+ .TS
+-tab(;);
++tab(;),nowarn;
+ l lx.
+ """ % title]
+ 
+@@ -655,7 +655,7 @@
+         '.SH \"%s\"\n' % build.nroff.text_to_nroff(title.upper() + " FIELDS"),
+         '.SS "Summary:"\n',
+         '.TS\n',
+-        'tab(;);\n',
++        'tab(;),nowarn;\n',
+         'l l l l l l l.\n',
+         'Name;Bytes;Mask;RW?;Prereqs;NXM/OXM Support\n',
+         '\_;\_;\_;\_;\_;\_\n']
+@@ -665,7 +665,7 @@
+     return ''.join(content)
+ 
+ def make_oxm_classes_xml(document):
+-    s = '''tab(;);
++    s = '''tab(;),nowarn;
+ l l l.
+ Prefix;Vendor;Class
+ \_;\_;\_
+diff -ur openvswitch-2.17.7.orig/lib/meta-flow.xml openvswitch-2.17.7/lib/meta-flow.xml
+--- openvswitch-2.17.7.orig/lib/meta-flow.xml	2023-06-27 14:30:44.000000000 +0000
++++ openvswitch-2.17.7/lib/meta-flow.xml	2025-01-22 13:58:45.365148939 +0000
+@@ -3517,6 +3517,7 @@
+     </p>
+ 
+     <tbl>
++nowarn;
+ r r r r r.
+ Criteria        OpenFlow 1.0    OpenFlow 1.1    OpenFlow 1.2+   NXM
+ \_      \_      \_      \_      \_

--- a/SOURCES/0001-docs-Run-tbl-preprocessor-in-manpage-check-rule.patch
+++ b/SOURCES/0001-docs-Run-tbl-preprocessor-in-manpage-check-rule.patch
@@ -1,0 +1,34 @@
+From 6180fefa835c7cad36e89f77f3d9de13c680fb88 Mon Sep 17 00:00:00 2001
+From: Colin Watson <cjwatson@ubuntu.com>
+Date: Mon, 21 Aug 2023 15:53:34 +0200
+Subject: [PATCH] docs: Run tbl preprocessor in manpage-check rule.
+
+If we omit this, groff 1.23.0 warns:
+
+  tbl preprocessor failed, or it or soelim was not run; table(s) likely
+  not rendered (TE macro called with TW register undefined)
+
+Reported-by: Lucas Nussbaum <lucas@debian.org>
+Reported-at: https://bugs.debian.org/1042358
+Signed-off-by: Colin Watson <cjwatson@ubuntu.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index db341504d..265cf0a7b 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -368,7 +368,7 @@ ALL_LOCAL += manpage-check
+ manpage-check: $(man_MANS) $(dist_man_MANS) $(noinst_man_MANS)
+ 	@error=false; \
+ 	for manpage in $?; do \
+-	  LANG=en_US.UTF-8 groff -w mac -w delim -w escape -w input -w missing -w tab -T utf8 -man -p -z $$manpage >$@.tmp 2>&1; \
++	  LANG=en_US.UTF-8 groff -t -w mac -w delim -w escape -w input -w missing -w tab -T utf8 -man -p -z $$manpage >$@.tmp 2>&1; \
+ 	  if grep warning: $@.tmp; then error=:; fi; \
+ 	  rm -f $@.tmp; \
+ 	done; \
+-- 
+2.25.1
+

--- a/SOURCES/0001-ovs.tmac-Fix-troff-warning-in-versions-above-groff-1.patch
+++ b/SOURCES/0001-ovs.tmac-Fix-troff-warning-in-versions-above-groff-1.patch
@@ -1,0 +1,42 @@
+From 0945e1a5fa3d66749facd24f8c60f732f7220f11 Mon Sep 17 00:00:00 2001
+From: gordonwwang <gordonwwang@tencent.com>
+Date: Thu, 17 Aug 2023 11:04:39 +0800
+Subject: [PATCH] ovs.tmac: Fix troff warning in versions above groff-1.23.
+
+When the compilation dependency is groff-1.23, the following message is
+displayed in the compilation log, and the compilation fails:
+
+  troff:vswitchd/ovs-vswitchd.8:1298: warning: cannot select font 'CW'
+  make[1]: *** [Makefile:6761: manpage-check] Error 1
+
+CW font was removed and and now groff warns about non-existent font:
+ https://git.savannah.gnu.org/cgit/groff.git/commit/?id=d75ea8b2e283e37bd560e821fa4597065f36725f)
+
+Fix that by replacing CW with CR.  CW supposed to be an alias of CR
+anyway.
+
+Submitted-at: https://github.com/openvswitch/ovs/pull/416
+Co-authored-by: Xiaojie Chen <jackchanx@163.com>
+Signed-off-by: Xiaojie Chen <jackchanx@163.com>
+Signed-off-by: gordonwwang <gordonwwang@tencent.com>
+Signed-off-by: Ilya Maximets <i.maximets@ovn.org>
+---
+ lib/ovs.tmac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/ovs.tmac b/lib/ovs.tmac
+index 5f8f20afa..97b6fa3df 100644
+--- a/lib/ovs.tmac
++++ b/lib/ovs.tmac
+@@ -175,7 +175,7 @@
+ .  nr mE \\n(.f
+ .  nf
+ .  nh
+-.  ft CW
++.  ft CR
+ ..
+ .
+ .
+-- 
+2.25.1
+

--- a/SOURCES/local.conf
+++ b/SOURCES/local.conf
@@ -1,0 +1,2 @@
+[Unit]
+Before=snmpd.service

--- a/SPECS/openvswitch.spec
+++ b/SPECS/openvswitch.spec
@@ -1,6 +1,6 @@
-%global package_speccommit fc6660be6dedf78939d0c2a115aee72009704c84
+%global package_speccommit 1ff4e345c4a98e1852ec477e4513fcb25c302e0f
 %global usver 2.17.7
-%global xsver 2
+%global xsver 4
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 %global package_srccommit refs/tags/v2.17.7
 %global __python %{_bindir}/python3
@@ -18,28 +18,34 @@ Version: 2.17.7
 License: ASL 2.0 and GPLv2
 Release: %{?xsrel}%{?dist}
 Source0: openvswitch-2.17.7.tar.gz
-Patch0: CA-72973-hack-to-strip-temp-dirs-from-paths.patch
-Patch1: CP-15129-Convert-to-use-systemd-services.patch
-Patch2: CA-78639-dont-call-interface-reconfigure-anymore.patch
-Patch3: CA-153718-md5-verification-dvsc.patch
-Patch4: CP-9895-Add-originator-to-login_with_password-xapi-call.patch
-Patch5: CP-13181-add-dropping-of-fip-and-lldp.patch
-Patch6: use-old-db-port-6632-for-dvsc.patch
-Patch7: CA-243975-Fix-openvswitch-service-startup-failure.patch
-Patch8: CP-23098-Add-IPv6-multicast-snooping-toggle.patch
-Patch9: CA-265107-When-enable-igmp-snooping-cannot-receive-ipv6-multicast-traffic.patch
-Patch10: 0001-xenserver-fix-Python-errors-in-Citrix-changes.patch
-Patch11: 0002-O3eng-applied-patch-on-top-of-the-NSX-OVS.patch
-Patch12: 0003-update-bridge-fail-mode-settings-when-bridge-comes-up.patch
-Patch13: CP-23607-inject-multicast-query-msg-on-bond-port.patch
-Patch14: mlockall-onfault.patch
-Patch15: hide-logrotate-script-error.patch
+Patch0: 0001-docs-Run-tbl-preprocessor-in-manpage-check-rule.patch
+Patch1: 0001-ovs.tmac-Fix-troff-warning-in-versions-above-groff-1.patch
+Patch2: 0001-docs-Add-nowarn-region-option-to-tables.patch
+Patch3: CA-72973-hack-to-strip-temp-dirs-from-paths.patch
+Patch4: CP-15129-Convert-to-use-systemd-services.patch
+Patch5: CA-78639-dont-call-interface-reconfigure-anymore.patch
+Patch6: CA-153718-md5-verification-dvsc.patch
+Patch7: CP-9895-Add-originator-to-login_with_password-xapi-call.patch
+Patch8: CP-13181-add-dropping-of-fip-and-lldp.patch
+Patch9: use-old-db-port-6632-for-dvsc.patch
+Patch10: CA-243975-Fix-openvswitch-service-startup-failure.patch
+Patch11: CP-23098-Add-IPv6-multicast-snooping-toggle.patch
+Patch12: CA-265107-When-enable-igmp-snooping-cannot-receive-ipv6-multicast-traffic.patch
+Patch13: 0001-xenserver-fix-Python-errors-in-Citrix-changes.patch
+Patch14: 0002-O3eng-applied-patch-on-top-of-the-NSX-OVS.patch
+Patch15: 0003-update-bridge-fail-mode-settings-when-bridge-comes-up.patch
+Patch16: CP-23607-inject-multicast-query-msg-on-bond-port.patch
+Patch17: mlockall-onfault.patch
+Patch18: hide-logrotate-script-error.patch
+# Moved form openvswitch.service.d/local.conf in xenserver-release
+Source1: local.conf
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 BuildRequires: systemd
 BuildRequires: openssl, openssl-devel, python3
 BuildRequires: autoconf, automake, libtool
+BuildRequires: groff
 %if %{with_asan}
 BuildRequires: libasan
 %endif
@@ -138,6 +144,13 @@ install -d -m 755 %{buildroot}/%{_datadir}/openvswitch/python/ovs/compat/sortedc
 install -d -m 755 %{buildroot}/%{_datadir}/openvswitch/python/ovs/db/__pycache__
 install -d -m 755 %{buildroot}/%{_datadir}/openvswitch/python/ovs/unixctl/__pycache__
 
+# For xs9, move this config here from xenserver-release
+%if 0%{?xenserver} >= 9
+mkdir -p %{buildroot}/%{_sysconfdir}/systemd/system/openvswitch.service.d
+install -m 644 -p %{SOURCE1} \
+        %{buildroot}/%{_sysconfdir}/systemd/system/openvswitch.service.d/local.conf
+%endif
+
 #install python/compat/uuid.py %{buildroot}/%{_datadir}/openvswitch/python
 #install python/compat/argparse.py %{buildroot}/%{_datadir}/openvswitch/python
 
@@ -172,6 +185,9 @@ install -d -m 755 %{buildroot}/%{_datadir}/openvswitch/python/ovs/unixctl/__pyca
 %dir %{_var}/log/openvswitch
 %{_sysconfdir}/bash_completion.d/ovs-appctl-bashcomp.bash
 %{_sysconfdir}/bash_completion.d/ovs-vsctl-bashcomp.bash
+%if 0%{?xenserver} >= 9
+%{_sysconfdir}/systemd/system/openvswitch.service.d/local.conf
+%endif
 %{_bindir}/ovs-docker
 %{_bindir}/ovs-testcontroller
 %{_bindir}/ovs-appctl
@@ -322,6 +338,12 @@ Open vSwitch Linux kernel module compiled against kernel version
 %endif
 
 %changelog
+* Wed Jan 22 2025 Alex Brett <alex.brett@cloud.com> - 2.17.7-4
+- CA-405118: Backport 3 patches to handle updated groff
+
+* Thu Dec 12 2024 Stephen Cheng <stephen.cheng@cloud.com> - 2.17.7-3
+- CP-50699: For xs9, move config file for openvswitch.service from xenserver-release
+
 * Thu Jun 13 2024 Lin Liu <Lin.Liu01@cloud.com> - 2.17.7-2
 - CP-46117: Refresh patches to build with XS9
 


### PR DESCRIPTION
* rebuild for openssl3
* move config file for openvswitch.service from xenserver-release, that we have to check in our own package
scratch build: https://koji.xcp-ng.org/taskinfo?taskID=89680

Updates from @rzr:

- [ ] https://koji.xcp-ng.org/taskinfo?taskID=94421
- [x] Koji pre-build XCPNG2710 (v8.3-u-pcoval2): https://koji.xcp-ng.org/taskinfo?taskID=94421
